### PR TITLE
Fixes filename sanitization in configuration download

### DIFF
--- a/main.py
+++ b/main.py
@@ -117,8 +117,9 @@ add allowed-address={client_ip}/32 interface={iface_name} public-key="{pub}" com
 @app.route('/download_conf')
 def download_conf():
     client_name = request.args.get('name', 'cliente')
+    client_name = client_name.replace(" ", "")
     conf_data = request.args.get('data', '')
-    return send_file(io.BytesIO(conf_data.encode()), download_name=f"{client_name.replace(" ", "")}.conf", as_attachment=True)
+    return send_file(io.BytesIO(conf_data.encode()), download_name=f"{client_name}.conf", as_attachment=True)
 
 if __name__ == '__main__':
     app.run(host="0.0.0.0", port=8080)


### PR DESCRIPTION
Ensures client names are sanitized by removing spaces before generating configuration file names to prevent potential issues during file handling.